### PR TITLE
Cuando una instancia está en mantenimiento no se consumen sus tareas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ To run the examples make sure that the redis server is up.
 Install Django.
 
 Create a symbolic link inside your virtualenv site-packages to the huey_multitenant folder.
+The current version of huey_multitenant can also be installed using `python setup.py install`.
 
 Create django1.conf file inside bin/conf folder with this content (replace PATH):
 

--- a/examples/django_1/django_1/settings.py
+++ b/examples/django_1/django_1/settings.py
@@ -15,6 +15,30 @@ HUEY = {
         'workers': 2,
         'scheduler_interval': 5,
     },
+    'connection': {
+        'port': 16379,
+    },
+}
+
+HUEY_CHECK_MAINTENANCE = "django_1.test_app.maintenance.is_in_maintenance"
+
+REDIS_PROTOCOL = 'redis'
+REDIS_HOST = 'localhost'
+REDIS_PORT = 16379
+REDIS_DB = 0
+REDIS_URL = u"{protocol}://{host}:{port}/{db}".format(protocol=REDIS_PROTOCOL,
+                                                      host=REDIS_HOST,
+                                                      port=REDIS_PORT,
+                                                      db=REDIS_DB)
+CACHES = {
+    'default': {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': REDIS_URL,
+        'KEY_PREFIX': 'django_1',
+        'OPTIONS': {
+            'CLIENT_CLASS': 'django_redis.client.DefaultClient'
+        }
+    },
 }
 
 SECRET_KEY = 'foo'

--- a/examples/django_1/django_1/settings.py
+++ b/examples/django_1/django_1/settings.py
@@ -20,6 +20,8 @@ HUEY = {
     },
 }
 
+# Location of method to check maintenance status of the app
+# Used by huey-multitenant
 HUEY_CHECK_MAINTENANCE = "django_1.test_app.maintenance.is_in_maintenance"
 
 REDIS_PROTOCOL = 'redis'

--- a/examples/django_1/django_1/test_app/maintenance.py
+++ b/examples/django_1/django_1/test_app/maintenance.py
@@ -1,0 +1,9 @@
+from django.core.cache import cache
+
+
+def is_in_maintenance():
+    return cache.get("maintenance", default=False)
+
+
+def set_maintenance(value):
+    cache.set("maintenance", value)

--- a/examples/django_2/django_2/settings.py
+++ b/examples/django_2/django_2/settings.py
@@ -16,6 +16,9 @@ HUEY = {
         'workers': 2,
         'scheduler_interval': 5,
     },
+    'connection': {
+        'port': 16379,
+    },
 }
 
 SECRET_KEY = 'foo'

--- a/huey_multitenant/application.py
+++ b/huey_multitenant/application.py
@@ -2,6 +2,7 @@ import datetime
 import subprocess
 import logging
 import os
+from pickle import loads, UnpicklingError
 import signal
 import threading
 import time
@@ -28,6 +29,7 @@ class HueyApplication(object):
                  redis_host,
                  redis_port,
                  redis_prefix,
+                 redis_maintenance_key,
                  use_python3=False):
         self._logger = logging.getLogger()
         self._logger.info('\nRegister App: %s\nWorker Type: %s\nWorkers: %s', name, worker_type, workers)
@@ -37,6 +39,7 @@ class HueyApplication(object):
             host=redis_host,
             port=redis_port)
         self.name = name
+        self.redis_maintenance_key = redis_maintenance_key
         self.workers = workers
         if worker_type in ['process', 'greenlet']:
             self.worker_type = worker_type
@@ -49,6 +52,15 @@ class HueyApplication(object):
         self.periodic_tasks = []
         self.use_python3 = use_python3
         self.load_periodic_tasks()
+
+    def is_in_maintenance_mode(self):
+        encoded_data = self.storage.conn.get(self.redis_maintenance_key)
+        if encoded_data is None:
+            return False
+        try:
+            return loads(encoded_data)
+        except UnpicklingError:
+            return False
 
     def load_periodic_tasks(self):
         """

--- a/huey_multitenant/application.py
+++ b/huey_multitenant/application.py
@@ -60,6 +60,8 @@ class HueyApplication(object):
         try:
             return loads(encoded_data)
         except UnpicklingError:
+            self._logger.error('Error unpickling maintenance mode key {}, using maintenance mode off'.format(
+                self.redis_maintenance_key))
             return False
 
     def load_periodic_tasks(self):

--- a/huey_multitenant/application.py
+++ b/huey_multitenant/application.py
@@ -54,6 +54,8 @@ class HueyApplication(object):
         self.load_periodic_tasks()
 
     def is_in_maintenance_mode(self):
+        # CAUTION: If you change the logic to decide if the system
+        # is in maintenance mode or not, also change it in neo-assets
         encoded_data = self.storage.conn.get(self.redis_maintenance_key)
         if encoded_data is None:
             return False

--- a/huey_multitenant/core.py
+++ b/huey_multitenant/core.py
@@ -136,7 +136,6 @@ class Dispatcher(object):
                     redis_host=parser.get(section, 'redis_host'),
                     redis_port=parser.get(section, 'redis_port'),
                     redis_prefix=parser.get(section, 'redis_prefix') or section,
-                    redis_maintenance_key=parser.get(section, 'redis_maintenance_key', fallback=None),
                     use_python3=parser.getboolean(section, 'use_python3', fallback=False)
                 )
         except Exception as e:
@@ -167,9 +166,6 @@ class Dispatcher(object):
 
     def consume_task(self):
         for idx, _instance in enumerate(self.instances):
-            if _instance.is_in_maintenance_mode():
-                self._logger.info('Instance %s is in maintenance mode, skipping its tasks', _instance.name)
-                continue
             tasks = _instance.get_pending_tasks()
             for _task in tasks:
                 task_id, task_klass = self.get_task_data(_task)

--- a/huey_multitenant/core.py
+++ b/huey_multitenant/core.py
@@ -167,8 +167,6 @@ class Dispatcher(object):
 
     def consume_task(self):
         for idx, _instance in enumerate(self.instances):
-            # if self.instance_is_active(_instance):
-            #     continue
             if _instance.is_in_maintenance_mode():
                 self._logger.info('Instance %s is in maintenance mode, skipping its tasks', _instance.name)
                 continue

--- a/huey_multitenant/core.py
+++ b/huey_multitenant/core.py
@@ -136,6 +136,7 @@ class Dispatcher(object):
                     redis_host=parser.get(section, 'redis_host'),
                     redis_port=parser.get(section, 'redis_port'),
                     redis_prefix=parser.get(section, 'redis_prefix') or section,
+                    redis_maintenance_key=parser.get(section, 'redis_maintenance_key', fallback=None),
                     use_python3=parser.getboolean(section, 'use_python3', fallback=False)
                 )
         except Exception as e:
@@ -168,6 +169,9 @@ class Dispatcher(object):
         for idx, _instance in enumerate(self.instances):
             # if self.instance_is_active(_instance):
             #     continue
+            if _instance.is_in_maintenance_mode():
+                self._logger.info('Instance %s is in maintenance mode, skipping its tasks', _instance.name)
+                continue
             tasks = _instance.get_pending_tasks()
             for _task in tasks:
                 task_id, task_klass = self.get_task_data(_task)


### PR DESCRIPTION
Cuando en el round robin de procesamiento de tareas le toca a una instancia se chequea si está en mantenimiento y si es así no se consume ninguna de sus tareas y quedan encoladas hasta que la instancia vuelva a estar en funcionamiento. 

Hay que agregar "redis_maintenance_key" a la configuración de cada instancia con el valor de la key de redis que contiene el estado de mantenimiento.

## Related PRs 
[neo-assets#6599](https://github.com/InvGate/neo-assets/pull/6599) 
[neo-assets-front#9153](https://github.com/InvGate/neo-assets-front/pull/9153)