### PR TITLE
[OP5125] Procesar muchas tareas si hay disponibles

### DIFF
--- a/huey_multitenant/consumer.py
+++ b/huey_multitenant/consumer.py
@@ -10,7 +10,7 @@ import os
 from json import loads
 
 WORKER_IDLE_TIMEOUT = 1.
-WORKER_TIMEOUT = 20.
+WORKER_DEFAULT_TIMEOUT = 20.
 
 class ExecuteConsumer(Consumer):
     """
@@ -113,7 +113,9 @@ class ExecuteConsumer(Consumer):
         self.check_maintenance_mode()
         self.start()
 
-        self._stop_when_idle(start_time, idle_timeout=WORKER_IDLE_TIMEOUT, timeout=WORKER_TIMEOUT)
+        worker_timeout = getattr(settings, 'HUEY_WORKER_TIMEOUT', WORKER_DEFAULT_TIMEOUT)
+
+        self._stop_when_idle(start_time, idle_timeout=WORKER_IDLE_TIMEOUT, timeout=worker_timeout)
 
         total_seconds = (datetime.utcnow() - start_time).total_seconds()
         self._logger.info('Stop consumer. %s seconds' % total_seconds)

--- a/huey_multitenant/consumer.py
+++ b/huey_multitenant/consumer.py
@@ -2,10 +2,12 @@ from __future__ import unicode_literals, absolute_import
 
 from django.conf import settings
 from django.utils.module_loading import import_string
-from huey.consumer import Consumer
+from huey.consumer import Consumer, EVENT_FINISHED, EVENT_STARTED
 from huey.exceptions import ConfigurationError
-import time
+from time import sleep
+from datetime import timedelta, datetime
 import os
+from json import loads
 
 
 class ExecuteConsumer(Consumer):
@@ -53,18 +55,65 @@ class ExecuteConsumer(Consumer):
                 self._logger.info('MaintenanceMode is on, stopping consumer')
                 exit(0)
 
+    def _stop_when_idle(self, start_time, timeout=20.0):
+        """
+        Stops the workers as soon as they are idle.
+        With a maximum of timeout seconds
+        """
+
+        last_finished = datetime.utcnow()
+        working = False
+
+        def check_total_time():
+            self._logger.debug("Checking total time")
+            return datetime.utcnow() > (start_time + timedelta(seconds=timeout))
+        
+        def check_idle_time():
+            self._logger.debug("Checking idle time")
+            return (datetime.utcnow() > (last_finished + timedelta(seconds=1.))) and not working
+
+        listener = self.huey.storage.listener()
+
+        while True:
+            message = listener.get_message(ignore_subscribe_messages=True, timeout=0.5)
+            if message:
+                event = loads(message['data'].decode('utf-8'))
+                self._logger.debug("Got event from worker: {}".format(event))
+                if event and 'status' in event:
+                    if event['status'] == EVENT_FINISHED:
+                        last_finished = datetime.utcnow()
+                        working = False
+                    elif event['status'] == EVENT_STARTED:
+                        working = True
+                    else:
+                        # We may need to handle extra messages differently
+                        working = False
+
+            if check_total_time() or check_idle_time():
+                break
+
+        self._stop_worker()
+            
+
+    def _stop_worker(self):
+        self._logger.debug('Sending stop signal to workers')
+        self.stop_flag.set()
+        for _, worker_process in self.worker_threads:
+            worker_process.join()
+        
+
     def run(self):
         """
         Run the consumer.
         """
         self._logger.info('Start consumer.')
-        start_time = time.time()
+        start_time = datetime.utcnow()
 
         self.check_maintenance_mode()
         self.start()
-        time.sleep(1.0)
-        self.stop_flag.set()
-        for _, worker_process in self.worker_threads:
-            worker_process.join()
-        self._logger.info('Stop consumer. %s seconds' % (time.time() - start_time))
+
+        self._stop_when_idle(start_time)
+
+        total_seconds = (datetime.utcnow() - start_time).total_seconds()
+        self._logger.info('Stop consumer. %s seconds' % total_seconds)
         exit(0)


### PR DESCRIPTION
Como no es barato levantar el worker cada vez que tiene una tarea disponible, lo dejamos levantado por un máximo de 20segundos, o lo cortamos antes si pasa 1 segundo sin recibir tareas nuevas.